### PR TITLE
Refactor to reuse java.util.regex.Pattern

### DIFF
--- a/src/main/java/com/github/difflib/text/DiffRowGenerator.java
+++ b/src/main/java/com/github/difflib/text/DiffRowGenerator.java
@@ -49,9 +49,10 @@ import java.util.regex.Pattern;
 public class DiffRowGenerator {
 
     public static final Pattern SPLIT_BY_WORD_PATTERN = Pattern.compile("\\s+|[,.\\[\\](){}/\\\\*+\\-#]");
+    public static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
 
     public static final BiPredicate<String, String> IGNORE_WHITESPACE_EQUALIZER = (original, revised)
-            -> original.trim().replaceAll("\\s+", " ").equals(revised.trim().replaceAll("\\s+", " "));
+            -> adjustWhitespace(original).equals(adjustWhitespace(revised));
 
     public static final BiPredicate<String, String> DEFAULT_EQUALIZER = Object::equals;
 
@@ -467,5 +468,9 @@ public class DiffRowGenerator {
             }
         }
         return list;
+    }
+
+    private static String adjustWhitespace(String raw) {
+        return WHITESPACE_PATTERN.matcher(raw.trim()).replaceAll(" ");
     }
 }


### PR DESCRIPTION

`String.replaceAll ()` compiles the regular expression each time it is called.

```java
   public String replaceAll(String regex, String replacement) {
        return Pattern.compile(regex).matcher(this).replaceAll(replacement);
    }
```


It is suggested in [javadoc](https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html#matches(java.lang.String,%20java.lang.CharSequence)) that it is efficient to reuse the pattern, so I modified it accordingly.

> If a pattern is to be used multiple times, compiling it once and reusing it will be more efficient than invoking this method each time.

