### PR TITLE
Use Objects.hash() instead of custom hashCode() method

### DIFF
--- a/src/main/java/com/github/difflib/patch/AbstractDelta.java
+++ b/src/main/java/com/github/difflib/patch/AbstractDelta.java
@@ -63,11 +63,7 @@ public abstract class AbstractDelta<T> {
 
     @Override
     public int hashCode() {
-        int hash = 3;
-        hash = 61 * hash + Objects.hashCode(this.source);
-        hash = 61 * hash + Objects.hashCode(this.target);
-        hash = 61 * hash + Objects.hashCode(this.type);
-        return hash;
+        return Objects.hash(this.source, this.target, this.type);
     }
 
     @Override

--- a/src/main/java/com/github/difflib/patch/Chunk.java
+++ b/src/main/java/com/github/difflib/patch/Chunk.java
@@ -21,6 +21,7 @@ package com.github.difflib.patch;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Holds the information about the part of text involved in the diff process
@@ -108,26 +109,11 @@ public final class Chunk<T> {
         return getPosition() + size() - 1;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((lines == null) ? 0 : lines.hashCode());
-        result = prime * result + position;
-        result = prime * result + size();
-        return result;
+        return Objects.hash(lines, position, size());
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {

--- a/src/main/java/com/github/difflib/text/DiffRow.java
+++ b/src/main/java/com/github/difflib/text/DiffRow.java
@@ -20,6 +20,7 @@ limitations under the License.
 package com.github.difflib.text;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Describes the diff row in form [tag, oldLine, newLine) for showing the difference between two texts
@@ -70,26 +71,11 @@ public final class DiffRow implements Serializable {
         return newLine;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((newLine == null) ? 0 : newLine.hashCode());
-        result = prime * result + ((oldLine == null) ? 0 : oldLine.hashCode());
-        result = prime * result + ((tag == null) ? 0 : tag.hashCode());
-        return result;
+        return Objects.hash(newLine, oldLine, tag);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {


### PR DESCRIPTION
Java's [Objects.hash()](https://docs.oracle.com/javase/8/docs/api/java/util/Objects.html#hash-java.lang.Object...-) offers an easier implementation generating hash codes. I think, it is worth using them.